### PR TITLE
Create persistent volume claim only if no gateway is configured

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -4,5 +4,5 @@ variables:
     OPENEDX_RELEASE: lilac
 
 include:
-  - project: 'community/tutor-ci'
+  - project: 'aiwin/cloud/openedx/tutor-plugins'
     file: 'plugin-gitlab-ci.yml'

--- a/tutorminio/patches/k8s-volumes
+++ b/tutorminio/patches/k8s-volumes
@@ -1,3 +1,4 @@
+{% if not MINIO_GATEWAY %}
 ---
 apiVersion: v1
 kind: PersistentVolumeClaim
@@ -12,3 +13,4 @@ spec:
   resources:
     requests:
       storage: 5Gi
+{% endif %}


### PR DESCRIPTION
Add if condition on k8s-volumes to create PersistentVolumeClaim only when no MINIO_GATEWAY is configured