### PR TITLE
fix: store profile images in MinIO

### DIFF
--- a/tutorminio/patches/openedx-lms-common-settings
+++ b/tutorminio/patches/openedx-lms-common-settings
@@ -1,0 +1,9 @@
+# LMS-specific media storage
+PROFILE_IMAGE_BACKEND = {
+    "class": DEFAULT_FILE_STORAGE,
+    "options": {
+        "location": PROFILE_IMAGE_BACKEND["options"]["location"].lstrip("/"),
+        # the following non empty property is necessary in development
+        "base_url": "dummyprofileimagebaseurl",
+    },
+}


### PR DESCRIPTION
Previously, profile images were still being stored as media assets, thus
causing them to be lost at every restart.

Note that a non-empty base_url attribute is required in development, otherwise
the lms will crash. That's because of the following section in lms/urls.py:

    if settings.DEBUG:
        urlpatterns += static(
            settings.PROFILE_IMAGE_BACKEND['options']['base_url'],
            document_root=settings.PROFILE_IMAGE_BACKEND['options']['location']
        )

See: https://discuss.overhang.io/t/tutor-course-export-and-import-error-on-k8s-deployment/1692/9

This is ready for review @overhangio/tutor-developers. Cc @angonz.