### PR TITLE
Fix port for MinIO access in dev

### DIFF
--- a/changelog.d/20230713_093132_dave_fix_dev_port.md
+++ b/changelog.d/20230713_093132_dave_fix_dev_port.md
@@ -1,0 +1,1 @@
+- [Bugfix] Make LMS/Studio connnect to the right port in dev mode. (by @ormsbee)

--- a/tutorminio/patches/openedx-common-settings
+++ b/tutorminio/patches/openedx-common-settings
@@ -12,14 +12,3 @@ AWS_S3_ENDPOINT_URL = "{{ "https" if ENABLE_HTTPS else "http" }}://{{ MINIO_HOST
 AWS_AUTO_CREATE_BUCKET = False # explicit is better than implicit
 AWS_DEFAULT_ACL = None
 AWS_QUERYSTRING_EXPIRE = 7 * 24 * 60 * 60  # 1 week: this is necessary to generate valid download urls
-
-# User tasks assets storage
-# In theory we could use cms.djangoapps.contentstore.storage.ImportExportS3Storage,
-# but this class makes use of boto, which does not support sig3v4 auth.
-from storages.backends.s3boto3 import S3Boto3Storage
-class MinIOStorage(S3Boto3Storage):  # pylint: disable=abstract-method
-    def __init__(self):
-        bucket = "{{ MINIO_BUCKET_NAME }}"
-        super().__init__(bucket=bucket, custom_domain=None, querystring_auth=True)
-
-USER_TASKS_ARTIFACT_STORAGE = f"{__name__}.MinIOStorage"


### PR DESCRIPTION
The value for AWS_S3_ENDPOINT_URL set in openedx-development-settings
specifies port 9000, and it was being written to Studio and LMS settings
correctly. But this is the sequence of what was really happening:

1. openedx-common-settings first sets AWS_S3_ENDPOINT_URL WITHOUT port
   info, since this is how it's used in prod deployments.
2. openedx-common-settings imports S3Boto3Storage because it wants to
   make a subclass to use for USER_TASKS_ARTIFACT_STORAGE.
3. The act of importing that pacakge has the side-effect of initializing
   the Django storages (django.core.files.storage.default_storage).
4. Because the DEFAULT_FILE_STORAGE class is S3Boto3Storage, it then
   reads the value of AWS_S3_ENDPOINT_URL (which has no port info), and
   sets this as the S3 conneciton information for the S3Boto3Storage
   instance at that time.
5. openedx-development-settings then comes along and changes the value
   of AWS_S3_ENDPOINT_URL to specify port 9000, but by this point it's
   too late to affect django-storages (though it will confuse folks who
   try to debug).

This commit removes the import that was causing the premature Django
storages initialization. The patch is no longer necessary because
ImportExportS3Storage was already moved to use S3Boto3Storage in
[31002ab](https://github.com/openedx/edx-platform/commit/31002ab).
