### PR TITLE
fix: MinIOStorage initialization is bad for dev

### DIFF
--- a/tutorminio/patches/openedx-development-settings
+++ b/tutorminio/patches/openedx-development-settings
@@ -1,1 +1,2 @@
 AWS_S3_ENDPOINT_URL = "{{ "https" if ENABLE_HTTPS else "http" }}://{{ MINIO_HOST }}:9000"
+MinIOStorage.endpoint_url = AWS_S3_ENDPOINT_URL


### PR DESCRIPTION
`S3Boto3Storage` initializes the host URL at the class level. This means that updating `AWS_S3_ENDPOINT_URL` after the initialization will have the desired effect

Before this fix; production settings are running fine. But development (local) will always fail in some tasks because the port number `9000` is not set to `AWS_S3_ENDPOINT_URL` before importing _anything_ from `s3boto3`. An example task that is failing is (Export Course in Studio)

Development settings before the fix:
* Initialize `AWS_S3_ENDPOINT_URL` without the dev port `9000`
* Import `S3Boto3Storage` from `s3boto3`
* `S3Boto3Storage.endpoint_url` is set to the value of `AWS_S3_ENDPOINT_URL`
* Class `MinIOStorage` declared, derived from `S3Boto3Storage`
* Add port `9000` to `AWS_S3_ENDPOINT_URL`
* Some `MinIOStorage` functionalities are failing because `MinIOStorage.endpoint_url` is set to the wrong value

Development settings after the fix:
* Initialize `AWS_S3_ENDPOINT_URL` without the dev port `9000`
* Import `S3Boto3Storage` from `s3boto3`
* `S3Boto3Storage.endpoint_url` is set to the value of `AWS_S3_ENDPOINT_URL`
* Class `MinIOStorage` declared, derived from `S3Boto3Storage`
* Add port `9000` to `AWS_S3_ENDPOINT_URL`
* _**Fix the value of `MinIOStorage.endpoint_url`**_
* No failures :)
