### PR TITLE
fix: unable to init and login in dev mode

### DIFF
--- a/changelog.d/20240222_190352_ghassan.maslamani_fix_dev_mode.md
+++ b/changelog.d/20240222_190352_ghassan.maslamani_fix_dev_mode.md
@@ -1,0 +1,1 @@
+- [Bugfix] Fix dev mode by inclduing the necessary env variables (by @ghassanmas).

--- a/tutorminio/patches/local-docker-compose-dev-services
+++ b/tutorminio/patches/local-docker-compose-dev-services
@@ -2,6 +2,9 @@ minio:
   ports:
     - "127.0.0.1:9000:9000"
     - "127.0.0.1:9001:9001"
+  environment:
+    MINIO_ROOT_USER: "{{ OPENEDX_AWS_ACCESS_KEY }}"
+    MINIO_ROOT_PASSWORD: "{{ OPENEDX_AWS_SECRET_ACCESS_KEY }}"
   networks:
     default:
       aliases:


### PR DESCRIPTION
Before this change, logging in at http://minio.local.edly.io:9001/ wasn't possible nor init it. This because necssary variable weren't passed dev compose patch