### PR TITLE
Feat: add support for discovery media in minio

### DIFF
--- a/changelog.d/20240702_152230_faraz.maqsood_add_separate_bucket_for_discovery.md
+++ b/changelog.d/20240702_152230_faraz.maqsood_add_separate_bucket_for_discovery.md
@@ -1,0 +1,1 @@
+- [Feature] Add support for discovery media files in minio and a separate bucket for discovery in Minio. (by @Faraz32123)

--- a/tutorminio/patches/discovery-common-settings
+++ b/tutorminio/patches/discovery-common-settings
@@ -1,0 +1,10 @@
+# MinIO object storage
+DEFAULT_FILE_STORAGE = "storages.backends.s3boto3.S3Boto3Storage"
+AWS_ACCESS_KEY_ID = "{{ OPENEDX_AWS_ACCESS_KEY }}"
+AWS_SECRET_ACCESS_KEY = "{{ OPENEDX_AWS_SECRET_ACCESS_KEY }}"
+AWS_S3_SIGNATURE_VERSION = "s3v4"
+AWS_S3_ENDPOINT_URL = "{% if ENABLE_HTTPS %}https{% else %}http{% endif %}://{{ MINIO_HOST }}"
+AWS_STORAGE_BUCKET_NAME = "discoveryuploads"
+AWS_S3_CUSTOM_DOMAIN = "{{ MINIO_HOST }}/discoveryuploads"
+AWS_S3_URL_PROTOCOL = "{% if ENABLE_HTTPS %}https{% else %}http{% endif %}:"
+AWS_QUERYSTRING_EXPIRE = 7 * 24 * 60 * 60  # 1 week: this is necessary to generate valid download urls

--- a/tutorminio/plugin.py
+++ b/tutorminio/plugin.py
@@ -34,6 +34,7 @@ config: dict[str, dict[str, t.Any]] = {
         "DOCKER_IMAGE": "docker.io/minio/minio:RELEASE.2022-03-26T06-49-28Z.hotfix.26ec6a857",
         "MC_DOCKER_IMAGE": "docker.io/minio/mc:RELEASE.2022-03-31T04-55-30Z",
         "GATEWAY": None,
+        "DISCOVERY_BUCKET_NAME": "{% if 'discovery' in PLUGINS %}discoveryuploads{% endif %}",
     },
     "unique": {
         "AWS_SECRET_ACCESS_KEY": "{{ 24|random_string }}",

--- a/tutorminio/templates/minio/tasks/minio/init.sh
+++ b/tutorminio/templates/minio/tasks/minio/init.sh
@@ -7,3 +7,14 @@ mc policy set public minio/{{ MINIO_BUCKET_NAME }}
 {% else %}
 echo "⚠️  It is your responsibility to grant public read access rights to the '{{ MINIO_BUCKET_NAME }}' bucket on Azure."
 {% endif %}
+
+# discovery bucket
+{% if MINIO_DISCOVERY_BUCKET_NAME %}
+mc mb --ignore-existing minio/{{ MINIO_DISCOVERY_BUCKET_NAME }}
+{% if MINIO_GATEWAY != "azure" %}
+# Make discovery media upload bucket public
+mc policy set public minio/{{ MINIO_DISCOVERY_BUCKET_NAME }}
+{% else %}
+echo "⚠️  It is your responsibility to grant public read access rights to the '{{ MINIO_DISCOVERY_BUCKET_NAME }}' bucket on Azure."
+{% endif %}
+{% endif %}


### PR DESCRIPTION
When Minio's init script will run, it will check if discovery is enabled in the tutor setup. If it's enabled, it'll create it's bucket. I have also added discovery patch which will override course_discovery settings to shift from file storage to minio s3 storage.

close #41.