### PR TITLE
fix: add PROFILE_IMAGE_BACKEND settings for k8s

### DIFF
--- a/changelog.d/20241010_170607_faraz.maqsood.md
+++ b/changelog.d/20241010_170607_faraz.maqsood.md
@@ -1,0 +1,1 @@
+- [BugFix] Add PROFILE_IMAGE_BACKEND settings in minio using patch named `openedx-lms-production-settings` so that profile images persist in k8s deployment of openedx and profile images can work for both local and dev environment. (by @Faraz32123)

--- a/tutorminio/patches/openedx-lms-production-settings
+++ b/tutorminio/patches/openedx-lms-production-settings
@@ -1,0 +1,8 @@
+PROFILE_IMAGE_BACKEND = {
+    "class": DEFAULT_FILE_STORAGE,
+    "options": {
+        "bucket_name": "{{ MINIO_BUCKET_NAME }}",
+        "querystring_auth": False,
+        "location": PROFILE_IMAGE_BACKEND["options"]["location"].lstrip("/"),
+    },
+}


### PR DESCRIPTION
- Add PROFILE_IMAGE_BACKEND settings in tutor-minio using patch named
`openedx-lms-production-settings` so that profile images persist
in k8s deployment of openedx and profile images can work now for both
local(will use minio storage if minio plugin is enabled) and dev environment.
- In case of dev environment, backend expects the valid S3 `base_url`
key in the PROFILE_IMAGE_BACKEND settings. It will be using openedx `DEFAULT_FILE_STORAGE`.
- close #46