### PR TITLE
fix!: Migrate to STORAGES from DEFAULT_FILE_STORAGE

### DIFF
--- a/changelog.d/20250917_111934_abdul.rehman02_migrate_to_storages.md
+++ b/changelog.d/20250917_111934_abdul.rehman02_migrate_to_storages.md
@@ -1,0 +1,1 @@
+- 💥[Bugfix] Migrate from using DEFAULT_FILE_STORAGE to STORAGES as part of the major Django 5.2 upgrade in Open edX. (by @rehmansheikh222)

--- a/tutorminio/patches/discovery-common-settings
+++ b/tutorminio/patches/discovery-common-settings
@@ -1,5 +1,5 @@
 # MinIO object storage
-DEFAULT_FILE_STORAGE = "storages.backends.s3boto3.S3Boto3Storage"
+STORAGES["default"]["BACKEND"] = "storages.backends.s3boto3.S3Boto3Storage"
 AWS_ACCESS_KEY_ID = "{{ OPENEDX_AWS_ACCESS_KEY }}"
 AWS_SECRET_ACCESS_KEY = "{{ OPENEDX_AWS_SECRET_ACCESS_KEY }}"
 AWS_S3_SIGNATURE_VERSION = "s3v4"

--- a/tutorminio/patches/openedx-common-settings
+++ b/tutorminio/patches/openedx-common-settings
@@ -1,9 +1,9 @@
-DEFAULT_FILE_STORAGE = "storages.backends.s3boto3.S3Boto3Storage"
+STORAGES["default"]["BACKEND"] = "storages.backends.s3boto3.S3Boto3Storage"
 VIDEO_IMAGE_SETTINGS["STORAGE_KWARGS"]["location"] = VIDEO_IMAGE_SETTINGS["STORAGE_KWARGS"]["location"].lstrip("/")
 VIDEO_TRANSCRIPTS_SETTINGS["STORAGE_KWARGS"]["location"] = VIDEO_TRANSCRIPTS_SETTINGS["STORAGE_KWARGS"]["location"].lstrip("/")
 GRADES_DOWNLOAD["STORAGE_KWARGS"] = {"location": GRADES_DOWNLOAD["STORAGE_KWARGS"]["location"].lstrip("/")}
 GRADES_DOWNLOAD["STORAGE_KWARGS"]["bucket_name"] = "{{ MINIO_GRADES_BUCKET_NAME }}"
-OPENEDX_LEARNING["MEDIA"]["BACKEND"] = DEFAULT_FILE_STORAGE
+OPENEDX_LEARNING["MEDIA"]["BACKEND"] = STORAGES["default"]["BACKEND"]
 OPENEDX_LEARNING["MEDIA"]["OPTIONS"] = {
     'bucket_name': "{{ MINIO_OPENEDX_LEARNING_BUCKET_NAME }}",
 }                                    

--- a/tutorminio/patches/openedx-lms-production-settings
+++ b/tutorminio/patches/openedx-lms-production-settings
@@ -1,5 +1,5 @@
 PROFILE_IMAGE_BACKEND = {
-    "class": DEFAULT_FILE_STORAGE,
+    "class": STORAGES["default"]["BACKEND"],
     "options": {
         "bucket_name": "{{ MINIO_BUCKET_NAME }}",
         "querystring_auth": False,


### PR DESCRIPTION
This PR closes https://github.com/overhangio/tutor-minio/issues/63

This is a breaking change as we are migrating from using DEFAULT_FILE_STORAGE to STORAGES as the same migration has been made in the edx-platform repo https://github.com/openedx/edx-platform/pull/37002/files